### PR TITLE
Add HUMAN.md for manual steps

### DIFF
--- a/HUMAN.md
+++ b/HUMAN.md
@@ -1,0 +1,18 @@
+# Manual Tasks and Environment Requirements
+
+This file collects steps that **cannot be automated** and therefore require a human to perform them. AI agents should append a short entry whenever they discover such a requirement.
+
+## When to add an entry
+
+- Secret provisioning or credential setup that cannot be stored in the repository.
+- Operating system or hardware changes that must be executed outside of Docker.
+- Any manual verification or process that a human must complete before CI/CD can succeed.
+
+## Format
+
+Use a bullet list with a brief description and the date. Example:
+
+- 2023-01-01: Obtain API key for service X and place it in `.env`.
+- 2023-01-02: Run `docker compose build` after installing new system packages.
+
+Keep entries concise and update them when the requirement is no longer relevant.

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -11,6 +11,7 @@ This file is **pulled automatically** by autonomous agents (for example, the Ope
    * Mark the TODO item as done.
    * If the change impacts the big picture, reflect it in `docs/ROADMAP.md`.
    * Add a short entry in `changelog/` describing *what* and *why* you changed.
+   * Record any manual steps or environment requirements in `HUMAN.md`.
 5. Request review or merge.
 
 ## 2. Coding conventions

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Instead of shipping a monolithic boiler-plate, VibeCoding starts with only the s
 * A clear, up-to-date **ROADMAP** that explains *where* we are heading.
 * A living **TODO** list that breaks the roadmap into small, bite-sized tasks.
 * **Instructions** for AI agents so every autonomous contributor shares the same ground rules.
+* **HUMAN.md** records manual steps or environment requirements that require a human touch.
 * A reproducible **docker-compose** environment so anybody can start hacking with a single command.
 * Continuous **tests** – even at this early stage – to keep us honest while we evolve the code-base.
 
@@ -34,7 +35,7 @@ docker compose exec app pytest -q
 
 Pull-requests are welcome!  Please read `docs/CONTRIBUTING.md` for guidelines.
 
-If you are an **AI agent** (👋), read `INSTRUCTIONS.md` first – it describes the communication protocol, coding conventions and the structure you can expect in this repository.
+If you are an **AI agent** (👋), read `INSTRUCTIONS.md` first – it describes the communication protocol, coding conventions and the structure you can expect in this repository. Consult `HUMAN.md` for any tasks that require human intervention.
 
 ## Project status
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -10,3 +10,10 @@ def test_readme_exists():
 
     readme = pathlib.Path(__file__).resolve().parents[1] / "README.md"
     assert readme.exists(), "README.md should exist at repository root"
+
+
+def test_human_md_exists():
+    import pathlib
+
+    human = pathlib.Path(__file__).resolve().parents[1] / "HUMAN.md"
+    assert human.exists(), "HUMAN.md should exist at repository root"


### PR DESCRIPTION
## Summary
- add a HUMAN.md file so agents can record manual tasks
- reference HUMAN.md from README and INSTRUCTIONS
- check for HUMAN.md in basic tests

## Testing
- `black tests/test_sanity.py`
- `flake8 tests/test_sanity.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a9da971c832394edca16de9b284b