### PR TITLE
Add architecture outline

### DIFF
--- a/changelog/0004_architecture_doc.md
+++ b/changelog/0004_architecture_doc.md
@@ -1,0 +1,2 @@
+I added a high-level architecture document and noted in the roadmap that it must stay updated when modules change.
+

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,27 @@
+# Architecture Overview
+
+This document sketches the intended high-level design of VibeCoding.
+It will evolve as modules are added.
+
+## Core package
+
+All common utilities live in the `vibecoding` Python package. It holds
+logging, configuration and other helpers that future services can import.
+
+## Feature modules
+
+Each service or tool will reside in its own directory under `src/`
+or directly under the repository root. Modules may be written in
+other languages when appropriate. Regardless of language, every module
+must expose a minimal API so other parts of the system can interact
+with it via clearly defined interfaces.
+
+## Cross-language interaction
+
+Language-specific modules communicate through HTTP APIs, command-line
+interfaces or message queues. For example, a Python service could call a
+Rust CLI tool as a subprocess, or send requests to a FastAPI endpoint.
+The architecture favors loose coupling so components remain replaceable.
+
+Updates to this document should accompany any structural change to the
+code base.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,6 +12,7 @@ Checklist:
 * [x] Development tooling (`docker-compose`, `.env.example`).
 * [x] Test scaffolding (`pytest`, a sample test to keep CI green).
 * [x] Continuous Integration (GitHub Actions or similar).
+* [ ] Keep `docs/ARCHITECTURE.md` updated whenever the repository structure changes.
 
 ## Milestone 2 – Core package `vibecoding`
 
@@ -39,4 +40,4 @@ Once the core is stable, we will start separate micro-projects (e.g. a CLI tool,
 
 ---
 
-Last updated: 2025-06-11
+Last updated: 2025-06-12


### PR DESCRIPTION
## Summary
- describe the planned high-level architecture
- remind maintainers to update the architecture doc when modules change

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a9f496d4832382229890f72bd2f1